### PR TITLE
Harden release packaging signals

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: pytest
       - name: Build wheel and source distribution
         run: |
-          rm -rf build dist *.egg-info src/*.egg-info
+          rm -rf build dist ./*.egg-info src/*.egg-info
           python -m build --sdist --wheel
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,33 @@
-name: Release Check
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  release-check:
+  package:
+    name: Package and attest
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      artifact-metadata: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -30,3 +43,32 @@ jobs:
         run: mypy src
       - name: Test
         run: pytest
+      - name: Build wheel and source distribution
+        run: |
+          rm -rf build dist *.egg-info src/*.egg-info
+          python -m build --sdist --wheel
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum telegram_resender-* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+      - name: Generate package provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/telegram_resender-*
+      - name: Upload package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telegram-resender-dist
+          path: dist/*
+          if-no-files-found: error
+      - name: Publish GitHub release assets
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY" --generate-notes --verify-tag
+          fi

--- a/README.en.md
+++ b/README.en.md
@@ -172,6 +172,21 @@ For production logs, use:
 TELEGRAM_RESENDER_LOG_FORMAT=JSON
 ```
 
+## Releases and Supply Chain
+
+- The Docker base image is pinned by digest in [Dockerfile](Dockerfile).
+- Python runtime/dev/audit dependencies install from hash-locked `requirements*.lock` files.
+- GitHub Actions are pinned by commit SHA.
+- The release workflow builds wheel and sdist packages, publishes `SHA256SUMS.txt`, and creates GitHub provenance attestations.
+- Dependency update rules are documented in [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).
+
+Release artifact verification:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+gh attestation verify telegram_resender-*.whl --repo krotname/TelegramResenderBot
+```
+
 ## Known limitations
 
 - This is bot-based intake/forwarding, not a userbot.
@@ -212,7 +227,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.
 
 ## Security
 
-See [SECURITY.md](SECURITY.md).
+See [SECURITY.md](SECURITY.md) and [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).
 
 ## License
 
@@ -221,6 +236,7 @@ GPL-3.0 License. See [LICENSE](LICENSE).
 ## Design docs
 
 - [Architecture](docs/architecture.md)
+- [Dependency policy](docs/DEPENDENCY_POLICY.md)
 - [Testing strategy](docs/testing.md)
 - [UX and competitive roadmap](docs/ux-competitive-roadmap.ru.md)
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ Production env template: [.env.production.example](.env.production.example).
 TELEGRAM_RESENDER_LOG_FORMAT=JSON
 ```
 
+## Релизы и Supply Chain
+
+- Docker base image закреплен по digest в [Dockerfile](Dockerfile).
+- Python runtime/dev/audit зависимости ставятся из hash-locked файлов `requirements*.lock`.
+- GitHub Actions закреплены по commit SHA.
+- Релизный workflow собирает wheel и sdist, публикует `SHA256SUMS.txt` и GitHub provenance attestation.
+- Правила обновления зависимостей описаны в [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).
+
+Проверка релизных артефактов:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+gh attestation verify telegram_resender-*.whl --repo krotname/TelegramResenderBot
+```
+
 ## Ограничения
 
 - Это bot-based intake/forwarding, не userbot.
@@ -198,4 +213,4 @@ mypy src tests
 
 ## Безопасность
 
-Смотрите [SECURITY.md](SECURITY.md).
+Смотрите [SECURITY.md](SECURITY.md) и [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).

--- a/README.ru.md
+++ b/README.ru.md
@@ -161,6 +161,21 @@ Production env template: [.env.production.example](.env.production.example).
 TELEGRAM_RESENDER_LOG_FORMAT=JSON
 ```
 
+## Релизы и Supply Chain
+
+- Docker base image закреплен по digest в [Dockerfile](Dockerfile).
+- Python runtime/dev/audit зависимости ставятся из hash-locked файлов `requirements*.lock`.
+- GitHub Actions закреплены по commit SHA.
+- Релизный workflow собирает wheel и sdist, публикует `SHA256SUMS.txt` и GitHub provenance attestation.
+- Правила обновления зависимостей описаны в [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).
+
+Проверка релизных артефактов:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+gh attestation verify telegram_resender-*.whl --repo krotname/TelegramResenderBot
+```
+
 ## Ограничения
 
 - Это bot-based intake/forwarding, не userbot.
@@ -195,4 +210,4 @@ mypy src tests
 
 ## Безопасность
 
-Смотрите [SECURITY.md](SECURITY.md).
+Смотрите [SECURITY.md](SECURITY.md) и [docs/DEPENDENCY_POLICY.md](docs/DEPENDENCY_POLICY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,10 @@ The maintainer aims to acknowledge valid reports within 48 hours and provide a r
 - Secrets are read from environment variables.
 - Tokens and credentials must not be stored in source files.
 - Startup validation blocks obvious placeholder credentials.
+
+## Supply-chain controls
+
+- Runtime, development, bootstrap, and audit dependencies are installed from hash-locked requirement files.
+- The Docker runtime base image is pinned by immutable digest.
+- GitHub Actions are pinned by commit SHA.
+- Release packages are published with SHA-256 checksums and GitHub artifact attestations.

--- a/docs/DEPENDENCY_POLICY.md
+++ b/docs/DEPENDENCY_POLICY.md
@@ -1,0 +1,36 @@
+# Dependency Policy
+
+This repository treats runtime dependencies, developer tools, Docker runtime, and
+GitHub Actions as supply-chain inputs.
+
+## Python Dependencies
+
+- `requirements.lock` pins runtime dependencies with hashes.
+- `requirements-dev.lock` pins test, lint, type-check, and build tooling with hashes.
+- `requirements-bootstrap.lock` pins bootstrap tooling used before installing the other locks.
+- `requirements-audit.lock` pins audit tooling used by CI security checks.
+
+CI and Docker installs use `pip install --require-hashes` so an unpinned or
+unexpected package version fails the build.
+
+## Docker Runtime
+
+The Docker base image is pinned by digest in `Dockerfile`. Update it only through
+a reviewed dependency-maintenance change that rebuilds and retests the image.
+
+## GitHub Actions
+
+Workflow actions are pinned by immutable commit SHA with the original tag kept in
+a comment for readability. Dependabot groups workflow updates so each change can
+be reviewed as a supply-chain update.
+
+## Releases
+
+The release workflow builds the wheel and source distribution from a clean tree,
+publishes `SHA256SUMS.txt`, and creates GitHub artifact attestations for package
+provenance. Release assets should be verified before deployment:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+gh attestation verify telegram_resender-*.whl --repo krotname/TelegramResenderBot
+```

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1014,9 +1014,9 @@ pydantic-core==2.46.4 \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
     # via pydantic
-pydantic-settings==2.14.1 \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
     # via telegram-resender (pyproject.toml)
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \

--- a/requirements.lock
+++ b/requirements.lock
@@ -699,9 +699,9 @@ pydantic-core==2.46.4 \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
     # via pydantic
-pydantic-settings==2.14.1 \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
     # via telegram-resender (pyproject.toml)
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \


### PR DESCRIPTION
## Summary
- convert the release workflow into a package-and-attest flow for wheel/sdist assets
- publish SHA256SUMS and GitHub provenance attestations on tag releases
- document dependency locks, Docker digest pinning, and release verification

## Validation
- `ruff check src tests`
- `mypy src`
- `pytest`
- `python -m build --sdist --wheel`
- workflow YAML parse and bash syntax checks
- `git diff --check`