### PR TITLE
Fix Scorecard SARIF publication

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,7 @@ jobs:
       actions: read
       checks: read
       contents: read
+      id-token: write
       issues: read
       pull-requests: read
       security-events: write
@@ -27,40 +28,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - name: Install Scorecard CLI
-        env:
-          SCORECARD_VERSION: "5.5.0"
-          SCORECARD_SHA256: "83b90a05c1540ef1390db1cd5711e5fd04be9c1d8537fb84d39d02092d6a8dff"
-        run: |
-          set -euo pipefail
-          archive="scorecard_${SCORECARD_VERSION}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${archive}"
-          echo "${SCORECARD_SHA256}  ${archive}" | sha256sum -c -
-          mkdir -p "$RUNNER_TEMP/scorecard"
-          tar -xzf "${archive}" -C "$RUNNER_TEMP/scorecard" scorecard
-          chmod 0755 "$RUNNER_TEMP/scorecard/scorecard"
-      - name: Analyze
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          "$RUNNER_TEMP/scorecard/scorecard" \
-            --repo="github.com/${{ github.repository }}" \
-            --commit="${GITHUB_SHA}" \
-            --format=json \
-            --output="scorecard-results.json" \
-            --show-details
-      - name: Analyze SARIF
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          "$RUNNER_TEMP/scorecard/scorecard" \
-            --repo="github.com/${{ github.repository }}" \
-            --commit="${GITHUB_SHA}" \
-            --format=sarif \
-            --output="scorecard-results.sarif" \
-            --show-details
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
       - name: Upload Scorecard SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
@@ -69,7 +42,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: openssf-scorecard
-          path: |
-            scorecard-results.json
-            scorecard-results.sarif
+          path: scorecard-results.sarif
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- use pinned ossf/scorecard-action for SARIF output
- grant OIDC permission required by publish_results
- upload Scorecard SARIF to Code Scanning