### PR TITLE
Harden release build isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build wheel and source distribution
         run: |
           rm -rf build dist ./*.egg-info src/*.egg-info
-          python -m build --sdist --wheel
+          python -m build --sdist --wheel --no-isolation
       - name: Generate checksums
         run: |
           cd dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.0.0", "wheel"]
+requires = ["setuptools==82.0.1", "wheel==0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1070,6 +1070,10 @@ ruff==0.15.18 \
     --hash=sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4 \
     --hash=sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3
     # via telegram-resender (pyproject.toml)
+setuptools==82.0.1 \
+    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
+    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+    # via telegram-resender (pyproject.toml)
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
@@ -1088,6 +1092,10 @@ typing-inspection==0.4.2 \
     # via
     #   pydantic
     #   pydantic-settings
+wheel==0.47.0 \
+    --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced \
+    --hash=sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3
+    # via telegram-resender (pyproject.toml)
 yarl==1.24.2 \
     --hash=sha256:0063adad533e57171b79db3943b229d40dfafeeee579767f96541f106bac5f1b \
     --hash=sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30 \


### PR DESCRIPTION
### Motivation
- Prevent a PEP 517 build-time supply-chain risk where the release job ran `python -m build` in isolated mode and therefore could install unpinned build-backend dependencies (`setuptools`, `wheel`) outside the hash-locked environment.
- Ensure artifacts are produced using build backend versions and hashes already installed under `--require-hashes` so checksums and attestations cover the final, locked build output.

### Description
- Update the release workflow in `.github/workflows/release.yml` to run the build with `python -m build --sdist --wheel --no-isolation` so the job uses the pre-installed, hash-locked environment.
- Pin the PEP 517 build-system requirements in `pyproject.toml` to exact versions `setuptools==82.0.1` and `wheel==0.47.0`.
- Add hashed `setuptools==82.0.1` and `wheel==0.47.0` entries to `requirements-dev.lock` so `python -m pip install --require-hashes -r requirements-dev.lock` installs exact, hashed build-backend wheels prior to the non-isolated build.

### Testing
- Verified `pyproject.toml` parses with `tomllib` using `python - <<'PY' ... tomllib.load(...) ... PY`, which succeeded.
- Asserted the release workflow contains both the hashed install step and the guarded build invocation using `python -m build --no-isolation`, which succeeded.
- Attempted `python -m pytest` in the container, but the run failed due to test runner configuration requiring `pytest-cov` options that are not available in this environment, so end-to-end test execution was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3afc76ef8c8327b0ab829426ab03d3)