### PR TITLE
Restrict route keyword matching to building field

### DIFF
--- a/src/telegram_resender/service.py
+++ b/src/telegram_resender/service.py
@@ -95,7 +95,7 @@ class ResenderService:
         matching_routes = tuple(
             route
             for route in self._routes
-            if route.matches(username=message.user.username, text=message.text)
+            if route.matches(username=message.user.username, text=parsed_request.fields["building"])
         )
         if not matching_routes:
             return ForwardingDecision(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -152,6 +152,51 @@ def test_service_routes_request_to_matching_destinations() -> None:
     assert service.render_forward_text_for_target(300, decision.forward_text).startswith("[all]")
 
 
+def test_service_matches_route_keywords_only_against_building_field() -> None:
+    """Keywords in free-form fields must not add unintended destinations."""
+
+    service = ResenderService(
+        whitelist=Whitelist(["alice"]),
+        formatter=MessageFormatter(),
+        request_accepted_message="ok",
+        access_denied_message="deny",
+        missing_username_message=RU_MESSAGES.access_denied_missing_username,
+        invalid_request_message=RU_MESSAGES.invalid_request,
+        missing_fields_message=RU_MESSAGES.missing_fields,
+        no_route_matched_message=RU_MESSAGES.no_route_matched,
+        locale="ru",
+        routes=(
+            RouteRule(
+                name="tower-a",
+                target_chat_id=200,
+                allowed_usernames=frozenset(),
+                keywords_any=("башня а",),
+                keywords_none=(),
+                template=None,
+            ),
+            RouteRule(
+                name="tower-b",
+                target_chat_id=300,
+                allowed_usernames=frozenset(),
+                keywords_any=("башня б",),
+                keywords_none=(),
+                template=None,
+            ),
+        ),
+    )
+
+    decision = service.handle_text(
+        IncomingMessage(
+            chat_id=1,
+            text=f"{VALID_REQUEST}\nКомментарий: пожалуйста не отправляйте в Башня Б",
+            user=UserProfile(username="alice"),
+        )
+    )
+
+    assert decision.should_forward is True
+    assert decision.target_chat_ids == (200,)
+
+
 def test_service_rejects_complete_request_when_no_route_matches() -> None:
     """A complete request should not be forwarded if all route filters reject it."""
 


### PR DESCRIPTION
### Motivation
- Route keyword filters were being evaluated against the full raw Telegram message text, which allowed a whitelisted sender to inject another route's keyword in free-form fields and cause PII disclosure to unintended targets. 
- Matching should use a trusted, parsed field (the `building` value) instead of attacker-controlled free text to enforce route isolation.

### Description
- Route selection now matches keywords against the parsed `building` field instead of `message.text` by passing `parsed_request.fields["building"]` to `RouteRule.matches` in `src/telegram_resender/service.py`.
- Added a regression test `test_service_matches_route_keywords_only_against_building_field` in `tests/unit/test_service.py` that asserts a keyword injected into a comment does not cause an extra route to be selected.
- Ran code formatting/linters which reformatted `service.py` as needed.

### Testing
- Ran formatter/linter checks: `python -m ruff format src/telegram_resender/service.py tests/unit/test_service.py` and `python -m ruff check src/telegram_resender/service.py tests/unit/test_service.py`, which passed.
- Ran targeted unit tests: `python -m pytest -o addopts='' tests/unit/test_service.py tests/unit/test_routes.py`, resulting in `8 passed` for those files.
- Attempted full test run `python -m pytest -o addopts=''` which failed with async test errors because `pytest-asyncio` is not installed in the environment, causing many async tests to fail; attempted `pip install -e '.[dev]'` to add dev deps but network access to package index failed (403) so dev dependencies were not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3afd06c5748327ab36b3a6df6551fb)