### PR TITLE
fix: upgrade setuptools past security advisory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==82.0.1", "wheel==0.47.0"]
+requires = ["setuptools==83.0.0", "wheel==0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1070,9 +1070,9 @@ ruff==0.15.18 \
     --hash=sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4 \
     --hash=sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3
     # via telegram-resender (pyproject.toml)
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via telegram-resender (pyproject.toml)
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \


### PR DESCRIPTION
## What changed

- upgrade the build-system setuptools pin from 82.0.1 to 83.0.0
- update the generated development lock entry and both verified distribution hashes

## Why

The post-merge Security audit flagged setuptools 82.0.1 as affected by PYSEC-2026-3447. Version 83.0.0 contains the fix and PyPI currently reports no known vulnerabilities for that release.

## Validation

- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src`
- `pytest -q` — 112 passed, 87.16% coverage
- verified setuptools 83.0.0 wheel and sdist SHA256 values against PyPI metadata through the user Chrome profile
