### PR TITLE
security: prevent recurrence of the committed-token leak

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,34 @@
+name: Secret scan
+
+on:
+  push:
+    # Every branch, not only the default one: catching a leaked credential on
+    # the branch it was pushed to is the point of this workflow.
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: a secret committed once stays a secret in that commit.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          # Inline PR comments would require `pull-requests: write`; this job
+          # stays read-only and reports through the job summary and the log.
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          # GITLEAKS_LICENSE is only required for organization-owned repos.

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,21 @@ build/
 *.egg-info/
 .mypy_cache/
 whitelist.csv
-!.env.example
 *.sqlite3
+
+# --- Secrets --------------------------------------------------------------
+# Real environment files hold TELEGRAM_RESENDER_BOT_TOKEN. The README and the
+# `doctor` CLI hint both tell operators to create `.env` and paste a live token
+# into it, so these files must never be committable.
+.env
+.env.*
+
+# ...but the placeholder-only templates stay tracked.
+!.env.example
+!.env.*.example
+
+# Legacy top-level configuration module. A `config.py` at the repository root
+# was committed in 2020 with live bot tokens and later deleted from the tree.
+# The leading slash anchors this to the repository root only: a real package
+# module such as `src/telegram_resender/config.py` must stay visible to git.
+/config.py

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# Gitleaks configuration for TelegramResenderBot.
+#
+# The upstream default ruleset is extended rather than replaced, so detectors
+# added by future gitleaks releases (including the Telegram bot token rule)
+# apply automatically without editing this file.
+
+title = "TelegramResenderBot secret scanning"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Remediated historical finding: the 2020 legacy top-level config.py"
+paths = [
+  # A top-level `config.py` was committed in 2020 carrying two live Telegram
+  # bot tokens and was later deleted from the tree. Both tokens have been
+  # REVOKED. The offending commits stay reachable through immutable
+  # `refs/pull/*` refs, so a history rewrite cannot remove them; without this
+  # entry every full-history scan would fail forever on an already-remediated
+  # finding and the workflow would be switched off or ignored.
+  #
+  # The pattern is ANCHORED on purpose. `^config\.py$` excuses ONLY the file at
+  # the repository root. An unanchored `config\.py` would also match paths such
+  # as `src/telegram_resender/config.py`, silently suppressing a NEW secret in
+  # a future config module - exactly the recurrence this scan exists to catch.
+  # Do not remove the `^` and `$`.
+  '''^config\.py$''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,20 +9,12 @@ title = "TelegramResenderBot secret scanning"
 [extend]
 useDefault = true
 
-[allowlist]
-description = "Remediated historical finding: the 2020 legacy top-level config.py"
-paths = [
-  # A top-level `config.py` was committed in 2020 carrying two live Telegram
-  # bot tokens and was later deleted from the tree. Both tokens have been
-  # REVOKED. The offending commits stay reachable through immutable
-  # `refs/pull/*` refs, so a history rewrite cannot remove them; without this
-  # entry every full-history scan would fail forever on an already-remediated
-  # finding and the workflow would be switched off or ignored.
-  #
-  # The pattern is ANCHORED on purpose. `^config\.py$` excuses ONLY the file at
-  # the repository root. An unanchored `config\.py` would also match paths such
-  # as `src/telegram_resender/config.py`, silently suppressing a NEW secret in
-  # a future config module - exactly the recurrence this scan exists to catch.
-  # Do not remove the `^` and `$`.
-  '''^config\.py$''',
-]
+# Gitleaks 8.24.3 does not include a detector for Telegram Bot API tokens.
+# Keep an explicit rule so this repository catches the credential format that
+# was historically leaked. Exact revoked findings are listed by fingerprint in
+# `.gitleaksignore`; no file path is globally exempted.
+[[rules]]
+id = "telegram-bot-token"
+description = "Telegram Bot API token"
+regex = '''\b[0-9]{8,12}:[A-Za-z0-9_-]{35}\b'''
+tags = ["telegram", "token"]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# Revoked Telegram bot tokens from the legacy repository-root config.py.
+# Fingerprints bind each exception to one exact historical commit, path, rule,
+# and line. A future token in config.py or any other file remains detectable.
+61a90b52f6e9e6ccc25f77204292866d90592ba0:config.py:telegram-bot-token:2
+6700db60b9bfb84d2ee8dd925850daf5b5ecf3ff:config.py:telegram-bot-token:2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,14 +47,14 @@ templates instead and keep the filled-in copies local.
 The `Secret scan` workflow (`.github/workflows/gitleaks.yml`) runs gitleaks on
 every push and on pull requests against the default branch, over the full git
 history (`fetch-depth: 0`). Rules come from the upstream gitleaks defaults,
-extended by `.gitleaks.toml`.
+extended by `.gitleaks.toml`. The repository also defines an explicit Telegram
+Bot API token detector because the gitleaks version used by CI does not include
+one in its default ruleset.
 
-The only allowlist entry is the anchored path `^config\.py$`, which covers a
-remediated 2020 leak in the repository-root `config.py`. Those tokens are
-revoked and the commits remain reachable through immutable `refs/pull/*` refs,
-so they cannot be removed. The anchors are load-bearing: an unanchored pattern
-would also excuse a future `src/telegram_resender/config.py`, which is precisely
-what the scan must keep catching.
+`.gitleaksignore` contains two fingerprints for the revoked historical findings
+in the repository-root `config.py`. Each exception is bound to an exact commit,
+path, rule, and line. No path is globally allowlisted, so a future token in
+`config.py` or any other file still fails the scan.
 
 If the workflow reports a finding, treat the credential as compromised: revoke
 and reissue it first, then clean up the source.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,51 @@ The maintainer aims to acknowledge valid reports within 48 hours and provide a r
 - Tokens and credentials must not be stored in source files.
 - Startup validation blocks obvious placeholder credentials.
 
+### Git-ignored secret files
+
+`.gitignore` keeps local credential files out of commits:
+
+- `.env` and every `.env.*` variant (for example `.env.production`) are ignored,
+  because they hold the real `TELEGRAM_RESENDER_BOT_TOKEN`.
+- The placeholder templates `.env.example`, `.env.production.example`, and
+  `.env.systemd.example` are re-included by negation patterns and stay tracked.
+- The legacy repository-root `/config.py` is ignored. The pattern is anchored to
+  the root, so a package module such as `src/telegram_resender/config.py` would
+  still be tracked and scanned.
+
+Never commit `whitelist.csv` or a populated `.env`; copy the `*.example`
+templates instead and keep the filled-in copies local.
+
+### Secret scanning in CI
+
+The `Secret scan` workflow (`.github/workflows/gitleaks.yml`) runs gitleaks on
+every push and on pull requests against the default branch, over the full git
+history (`fetch-depth: 0`). Rules come from the upstream gitleaks defaults,
+extended by `.gitleaks.toml`.
+
+The only allowlist entry is the anchored path `^config\.py$`, which covers a
+remediated 2020 leak in the repository-root `config.py`. Those tokens are
+revoked and the commits remain reachable through immutable `refs/pull/*` refs,
+so they cannot be removed. The anchors are load-bearing: an unanchored pattern
+would also excuse a future `src/telegram_resender/config.py`, which is precisely
+what the scan must keep catching.
+
+If the workflow reports a finding, treat the credential as compromised: revoke
+and reissue it first, then clean up the source.
+
+### Authorization uses immutable numeric user IDs
+
+The whitelist trust boundary is expressed in immutable numeric Telegram user IDs
+(`whitelist.csv`, one ID per line; `/whoami` reports a user's own ID). Populate
+it with numeric IDs only.
+
+Do not authorize by `@username`. Telegram usernames are mutable and can be
+released and re-registered by a different account, so a username-based rule
+silently transfers access to whoever claims the handle next. The route field
+`allowed_usernames` is an additional routing filter applied after the numeric
+whitelist check has already granted access; it is not an authorization
+mechanism and must not be used as one.
+
 ## Supply-chain controls
 
 - Runtime, development, bootstrap, and audit dependencies are installed from hash-locked requirement files.


### PR DESCRIPTION
Follow-up to the credential leak found during the security audit: a legacy root `config.py` carried two live Telegram bot tokens. Both tokens have already been revoked, so this PR prevents recurrence without changing runtime code.

- `.gitignore`: ignore `.env`, `.env.*`, and the legacy root `/config.py`, while keeping `*.example` templates tracked.
- Secret scanning: run gitleaks on every push and pull request with full history, pinned actions, and read-only permissions.
- Telegram detector: add an explicit Telegram Bot API token rule because gitleaks 8.24.3 does not include one in its default ruleset.
- Exact historical exceptions: `.gitleaksignore` contains only two fingerprints bound to the revoked findings' exact commit, path, rule, and line. No file path is globally allowlisted, so any future token in `config.py` or elsewhere still fails CI.
- `SECURITY.md`: document the controls and immutable numeric Telegram user-ID authorization.

Validation:
- gitleaks 8.24.3 full-history scan: pass (73 commits)
- synthetic new Telegram token canary: detected and rejected
- existing application suite on the prior runtime-only-equivalent head: 112 passed, coverage 87.16%

A history rewrite was deliberately avoided because old commits remain reachable; fingerprint-scoped exceptions preserve detection for every new finding.